### PR TITLE
Add prepareSecure method

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "freedom-for-firefox",
   "description": "Embracing a distributed web",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "homepage": "http://freedomjs.org",
   "bugs": {
     "url": "http://github.com/freedomjs/freedom-for-firefox/issues",

--- a/providers/tcp_socket.js
+++ b/providers/tcp_socket.js
@@ -35,6 +35,10 @@ Socket_firefox.prototype.connect = function(hostname, port, continuation) {
   continuation();
 };
 
+Socket_firefox.prototype.prepareSecure = function(continuation) {
+  continuation();
+};
+
 // TODO: handle failures.
 Socket_firefox.prototype.secure = function(continuation) {
   if (!this.hostname || !this.port || !this.clientSocket) {


### PR DESCRIPTION
Add prepareSecure method to tcpsocket, to fix https://github.com/uProxy/uproxy/issues/413 - In freedom-for-chrome, this will call .setPaused, but in freedom-for-firefox and node this will be a no-op
