### PR TITLE
Update core.tcpsocket.unit.spec.js

### DIFF
--- a/spec/core.tcpsocket.unit.spec.js
+++ b/spec/core.tcpsocket.unit.spec.js
@@ -1,21 +1,23 @@
+
 var ClientSocket = require('../providers/client_socket');
 var ServerSocket = require('../providers/server_socket');
 var provider = require('../providers/core.tcpsocket');
 
 describe("unit: core.tcpsocket", function() {
   var clientSocket, serverSocket;
+  var portNumber = Math.floor((Math.random() * 999) + 8001);
   beforeEach(function() {
-    serverSocket = new ServerSocket("localhost", 8081);
+    serverSocket = new ServerSocket("localhost", portNumber);
     serverSocket.listen();
     clientSocket = new ClientSocket();
   });
-  
+
   it("connects", function(done) {
     serverSocket.onConnect = function(sock) {
       serverSocket.disconnect();
       done();
     };
-    clientSocket.connect("localhost", 8081, false);
+    clientSocket.connect("localhost", portNumber, false);
   });
 
   it("receives data", function(done) {
@@ -28,7 +30,7 @@ describe("unit: core.tcpsocket", function() {
         done();
       });
     };
-    clientSocket.connect("localhost", 8081, false);
+    clientSocket.connect("localhost", portNumber, false);
     clientSocket.write(str2ab(stringMessage));
   });
 
@@ -81,3 +83,4 @@ describe("unit: core.tcpsocket", function() {
     socket.write(str2ab(INIT_XMPP), continuation);
   });
 });
+


### PR DESCRIPTION
proposed randomization of port 8081.
reason for proposal:test was keeping the port busy and was throwing following errors 

> > unit: core.tcpsocket connects failed
> > ReferenceError: socketTransportService is not defined in resource://jid1-mkagayemb0e5nq-at-jetpack/freedom_for_firefox_tests/data/spec.jsm (line 10714)
> > unit: core.tcpsocket receives data failed
> > NS_ERROR_SOCKET_ADDRESS_IN_USE: Component returned failure code: 0x804b0036 (NS_ERROR_SOCKET_ADDRESS_IN_USE) [nsIServerSocket.init](line 11270)
> > ReferenceError: socketTransportService is not defined in resource://jid1-mkagayemb0e5nq-at-jetpack/freedom_for_firefox_tests/data/spec.jsm (line 10714)
> > unit: core.tcpsocket secures socket with starttls failed
> > NS_ERROR_SOCKET_ADDRESS_IN_USE: Component returned failure code: 0x804b0036 (NS_ERROR_SOCKET_ADDRESS_IN_USE) [nsIServerSocket.init](line 11270)
> > ReferenceError: socketTransportService is not defined in resource://jid1-mkagayemb0e5nq-at-jetpack/freedom_for_firefox_tests/data/spec.jsm (line 10714)

new changes were tested and it was passing the test .
