### PR TITLE
Adding core.xhr and integration tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "es5-shim": "^4.0.0",
     "es6-promise": "^2.0.0",
     "folderify": "^0.6.0",
-    "freedom": "~0.6.15",
+    "freedom": "~0.6.16",
     "fs-extra": "^0.12.0",
     "glob": "^4.0.6",
     "grunt": "~0.4.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "es5-shim": "^4.0.0",
     "es6-promise": "^2.0.0",
     "folderify": "^0.6.0",
-    "freedom": "~0.6.16",
+    "freedom": "~0.6.18",
     "fs-extra": "^0.12.0",
     "glob": "^4.0.6",
     "grunt": "~0.4.2",
@@ -39,7 +39,7 @@
     "webrtc-adapter": "^0.0.5"
   },
   "peerDependencies": {
-    "freedom": "~0.6.13"
+    "freedom": "~0.6.18"
   },
   "scripts": {}
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "freedom-for-firefox",
   "description": "Embracing a distributed web",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "homepage": "http://freedomjs.org",
   "bugs": {
     "url": "http://github.com/freedomjs/freedom-for-firefox/issues",

--- a/spec/provider.integration.spec.js
+++ b/spec/provider.integration.spec.js
@@ -40,6 +40,10 @@ describe("integration: core.rtcpeerconnection",
     require("freedom/providers/core/core.rtcdatachannel"),
     setup));
 
+describe("integration: core.xhr", 
+    require("freedom/spec/providers/coreIntegration/xhr.integration.src").bind(this, 
+    require("freedom/providers/core/core.xhr"), setup));
+
 describe("integration: core.tcpsocket",
     require('freedom/spec/providers/coreIntegration/tcpsocket.integration.src').bind(this,
     require('../providers/core.tcpsocket'), setup));

--- a/src/entry.js
+++ b/src/entry.js
@@ -29,7 +29,8 @@ if (typeof Components !== 'undefined') {
     require('../providers/core.storage'),
     require('freedom/providers/core/core.view'),
     require('freedom/providers/core/core.oauth'),
-    require('freedom/providers/core/core.websocket')
+    require('freedom/providers/core/core.websocket'),
+    require('freedom/providers/core/core.xhr')
   ];
 
   freedom = function (manifest, options) {


### PR DESCRIPTION
About to cut a release but mostly had questions. There's 4 core.rtcpeerconnection and 1 core.tcpsocket integration tests failing consistently. Is this the status quo?
All core.xhr tests pass fine.

These are the failing tests:
>> integration: core.rtcpeerconnection Sends messages across data channels failed
>> integration: core.rtcpeerconnection Checks that Firefox actually signals data channel closing.
>> integration: core.rtcpeerconnection Closes Cleanly failed)
>> integration: core.rtcpeerconnection getStats works failed
>> integration: core.tcpsocket Gets info on client & server sockets failed

@bemasc @willscott input?