### PR TITLE
Soycode fixintegrationtests

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,27 +20,27 @@
   "devDependencies": {
     "async": "^0.9.0",
     "es5-shim": "^4.1.0",
-    "es6-promise": "^2.0.0",
+    "es6-promise": "^2.0.1",
     "folderify": "^0.6.0",
-    "freedom": "~0.6.21",
-    "fs-extra": "^0.16.0",
-    "glob": "^4.3.0",
-    "grunt": "~0.4.2",
-    "grunt-browserify": "^3.0.1",
-    "grunt-bump": "0.0.16",
+    "freedom": "~0.6.22",
+    "fs-extra": "^0.18.0",
+    "glob": "^5.0.3",
+    "grunt": "~0.4.5",
+    "grunt-browserify": "^3.6.0",
+    "grunt-bump": "0.3.0",
     "grunt-contrib-clean": "~0.6.0",
     "grunt-contrib-copy": "^0.8.0",
-    "grunt-contrib-jshint": "~0.11.0",
-    "grunt-mozilla-addon-sdk": "^0.3.2",
+    "grunt-contrib-jshint": "~0.11.1",
+    "grunt-mozilla-addon-sdk": "^0.4.0",
     "grunt-npm": "0.0.2",
-    "grunt-prompt": "^1.2.1",
-    "grunt-shell": "^1.1.1",
-    "jasmine-core": "^2.0.4",
+    "grunt-prompt": "^1.3.0",
+    "grunt-shell": "^1.1.2",
+    "jasmine-core": "^2.2.0",
     "node-json-minify": "^0.1.3-a",
     "webrtc-adapter": "^0.0.6"
   },
   "peerDependencies": {
-    "freedom": "~0.6.21"
+    "freedom": "~0.6.22"
   },
   "scripts": {}
 }

--- a/providers/client_socket.js
+++ b/providers/client_socket.js
@@ -43,7 +43,10 @@ nsIInputStreamCallback.prototype.onInputStreamReady = function(stream) {
     if (e.name !== 'NS_BASE_STREAM_CLOSED') {
       console.warn(e);
     }
-    this.socket.close();
+    this.socket.close({
+      errcode: 'TODO',
+      message: 'TODOMESSAGE'
+    });
     return;
   }
   if (this.socket.onConnect) {
@@ -136,7 +139,7 @@ ClientSocket.prototype.resume = function() {
   this.rawInputStream.asyncWait(this.inputStreamCallback, 0, 0, mainThread);
 };
 
-ClientSocket.prototype.close = function() {
+ClientSocket.prototype.close = function(err) {
   this.binaryReader.close(0);
   this.rawInputStream.close(0);
   if (this.transport) {
@@ -145,7 +148,7 @@ ClientSocket.prototype.close = function() {
   // Delete transport so getInfo doesn't think we are connected
   delete this.transport;
   if (typeof this.onDisconnect === 'function') {
-    this.onDisconnect();
+    this.onDisconnect(err);
   }
 };
 

--- a/providers/client_socket.js
+++ b/providers/client_socket.js
@@ -52,7 +52,7 @@ nsIInputStreamCallback.prototype.onInputStreamReady = function(stream) {
   }
 
   var lineData = binaryReader.readByteArray(bytesAvailable);
-  var buffer = ArrayBuffer(lineData.length);
+  var buffer = new ArrayBuffer(lineData.length);
   var typedBuffer = new Uint8Array(buffer);
   typedBuffer.set(lineData);
   if (typeof this.socket.onData === 'function') {
@@ -143,7 +143,7 @@ ClientSocket.prototype.close = function() {
     this.transport.close(0);
   }
   // Delete transport so getInfo doesn't think we are connected
-  delete this.transport; 
+  delete this.transport;
   if (typeof this.onDisconnect === 'function') {
     this.onDisconnect();
   }
@@ -164,7 +164,6 @@ ClientSocket.prototype.getInfo = function() {
               localAddress: nsINetAddrLocal.address,
               localPort: nsINetAddrLocal.port};
   return info;
-  
 };
 
 ClientSocket.prototype.setOnDataListener = function(listener) {

--- a/providers/client_socket.js
+++ b/providers/client_socket.js
@@ -102,6 +102,7 @@ ClientSocket.prototype.connect = function(hostname, port, startTls, continuation
       message: 'Socket already connected'
     });
   }
+  console.log("IN CLIENTSOCKET CONNECT");
   this.onConnect = continuation;
 
   var socketTypes = startTls ? ['starttls'] : [null];
@@ -113,6 +114,7 @@ ClientSocket.prototype.connect = function(hostname, port, startTls, continuation
                                                          null);
   this._setupTransport(transport);
   this.socketType = 'tcp';
+  console.log("DONE WITH INITIAL CLIENTSOCKET CONNECT");
 };
 
 // Called due to the setEventSync call.
@@ -148,7 +150,7 @@ ClientSocket.prototype.close = function(err) {
   // Delete transport so getInfo doesn't think we are connected
   delete this.transport;
   if (typeof this.onDisconnect === 'function') {
-    this.onDisconnect(err);
+    this.onDisconnect(undefined, err);
   }
 };
 

--- a/providers/core.tcpsocket.js
+++ b/providers/core.tcpsocket.js
@@ -33,20 +33,10 @@ Socket_firefox.prototype.close = function(continuation) {
     });
     return;
   }
-  var closeSuccess = false;
   if (this.clientSocket) {
     this.clientSocket.close();
-    closeSuccess = true;
   } else if (this.serverSocket) {
     this.serverSocket.disconnect();
-    closeSuccess = true;
-  }
-  if (closeSuccess) {
-    this.dispatchEvent("onDisconnect",
-		      {
-			"errcode": "SUCCESS",
-			"message": "Socket closed by call to close"
-		      });
   }
   continuation();
 };
@@ -54,6 +44,9 @@ Socket_firefox.prototype.close = function(continuation) {
 // TODO: handle failures.
 Socket_firefox.prototype.connect = function(hostname, port, continuation) {
   this.clientSocket = new ClientSocket();
+  this.clientSocket.onDisconnect = function(err) {
+    this.dispatchEvent("onDisconnect", err);
+  }.bind(this);
   this.clientSocket.setOnDataListener(this._onData.bind(this));
   this.clientSocket.connect(hostname, port, false, continuation);
   this.hostname = hostname;
@@ -158,7 +151,7 @@ Socket_firefox.prototype._onConnect = function(clientSocket) {
                                        host: this.host,
                                        port: this.port
                                      });
-  
+
 };
 
 /** REGISTER PROVIDER **/

--- a/providers/core.tcpsocket.js
+++ b/providers/core.tcpsocket.js
@@ -2,17 +2,17 @@ var ClientSocket = require('./client_socket');
 var ServerSocket = require('./server_socket');
 
 function Socket_firefox(cap, dispatchEvent, socketId) {
-  var incommingConnections = Socket_firefox.incommingConnections;
+  var incomingConnections = Socket_firefox.incomingConnections;
   this.dispatchEvent = dispatchEvent;
   this.socketId = socketId;
-  if (socketId in incommingConnections) {
-    this.clientSocket = incommingConnections[socketId];
-    delete incommingConnections[socketId];
+  if (socketId in incomingConnections) {
+    this.clientSocket = incomingConnections[socketId];
+    delete incomingConnections[socketId];
     this.clientSocket.setOnDataListener(this._onData.bind(this));
   }
 }
 
-Socket_firefox.incommingConnections = {};
+Socket_firefox.incomingConnections = {};
 Socket_firefox.socketNumber = 1;
 
 Socket_firefox.prototype.getInfo = function(continuation) {
@@ -24,10 +24,28 @@ Socket_firefox.prototype.getInfo = function(continuation) {
 };
 
 Socket_firefox.prototype.close = function(continuation) {
-  if(this.clientSocket) {
+  if (!this.hostname || !this.port || !this.clientSocket) {
+    continuation(undefined, {
+      "errcode": "SOCKET_CLOSED",
+      "message": "Cannot close non-connected socket"
+    });
+    return;
+  }
+  var closeSuccess = false;
+  if (this.clientSocket) {
     this.clientSocket.close();
+    closeSuccess = true;
   } else if (this.serverSocket) {
     this.serverSocket.disconnect();
+    closeSuccess = true;
+  }
+  if (closeSuccess) {
+    console.log("DISPATCHING ONDISCONNECTION");
+    this.dispatchEvent("onDisconnect",
+		      {
+			"errcode": "SUCCESS",
+			"message": "Socket closed by call to close"
+		      });
   }
   continuation();
 };
@@ -50,7 +68,7 @@ Socket_firefox.prototype.secure = function(continuation) {
   if (!this.hostname || !this.port || !this.clientSocket) {
     continuation(undefined, {
       "errcode": "NOT_CONNECTED",
-      "message": "Cannot Secure Not Connected Socket"
+      "message": "Cannot secure non-connected socket"
     });
     return;
   }
@@ -69,6 +87,13 @@ Socket_firefox.prototype.secure = function(continuation) {
 };
 
 Socket_firefox.prototype.write = function(buffer, continuation) {
+  if (!this.clientSocket) {
+    continuation(undefined, {
+      "errcode": "NOT_CONNECTED",
+      "message": "Cannot write non-connected socket"
+    });
+    return;
+  }
   if (this.clientSocket) {
     this.clientSocket.write(buffer);
     continuation();
@@ -105,7 +130,7 @@ Socket_firefox.prototype.listen = function(host, port, continuation) {
   if (typeof this.serverSocket !== 'undefined') {
     continuation(undefined, {
       "errcode": "ALREADY_CONNECTED",
-      "message": "Cannot Listen on existing socket."
+      "message": "Cannot listen on existing socket."
     });
   } else {
     try {
@@ -131,7 +156,8 @@ Socket_firefox.prototype._onData = function(buffer) {
 
 Socket_firefox.prototype._onConnect = function(clientSocket) {
   var socketNumber = Socket_firefox.socketNumber++;
-  Socket_firefox.incommingConnections[socketNumber] = clientSocket;
+  Socket_firefox.incomingConnections[socketNumber] = clientSocket;
+  console.log("DISPATCHING ONCONNECTION");
   this.dispatchEvent("onConnection", { socket: socketNumber,
                                        host: this.host,
                                        port: this.port

--- a/providers/core.tcpsocket.js
+++ b/providers/core.tcpsocket.js
@@ -49,11 +49,12 @@ Socket_firefox.prototype.connect = function(hostname, port, continuation) {
     this.dispatchEvent("onConnection", err);
     continuation(arg, err);
   }.bind(this);
-  this.clientSocket.onDisconnect = function(err) {
+  this.clientSocket.onDisconnect = function(arg, err) {
     console.log("CLIENT FIRING ONDISCONNECT");
     this.dispatchEvent("onDisconnect", err);
   }.bind(this);
   this.clientSocket.setOnDataListener(this._onData.bind(this));
+  console.log("ABOUT TO CONNECT");
   this.clientSocket.connect(hostname, port, false, onConnection);
   this.hostname = hostname;
   this.port = port;

--- a/providers/core.tcpsocket.js
+++ b/providers/core.tcpsocket.js
@@ -16,7 +16,9 @@ Socket_firefox.incomingConnections = {};
 Socket_firefox.socketNumber = 1;
 
 Socket_firefox.prototype.getInfo = function(continuation) {
-  if(this.clientSocket) {
+  if (!this.hostname || !this.port || !this.clientSocket) {
+    continuation({ "connected": false });
+  } else if(this.clientSocket) {
     continuation(this.clientSocket.getInfo());
   } else if (this.serverSocket) {
     continuation(this.serverSocket.getInfo());
@@ -92,9 +94,7 @@ Socket_firefox.prototype.write = function(buffer, continuation) {
       "errcode": "NOT_CONNECTED",
       "message": "Cannot write non-connected socket"
     });
-    return;
-  }
-  if (this.clientSocket) {
+  } else {
     this.clientSocket.write(buffer);
     continuation();
   }
@@ -106,11 +106,10 @@ Socket_firefox.prototype.pause = function(continuation) {
       "errcode": "NOT_CONNECTED",
       "message": "Can only pause a connected client socket"
     });
-    return;
+  } else {
+    this.clientSocket.pause();
+    continuation();
   }
-
-  this.clientSocket.pause();
-  continuation();
 };
 
 Socket_firefox.prototype.resume = function(continuation) {
@@ -119,11 +118,10 @@ Socket_firefox.prototype.resume = function(continuation) {
       "errcode": "NOT_CONNECTED",
       "message": "Can only resume a connected client socket"
     });
-    return;
+  } else {
+    this.clientSocket.resume();
+    continuation();
   }
-
-  this.clientSocket.resume();
-  continuation();
 };
 
 Socket_firefox.prototype.listen = function(host, port, continuation) {

--- a/spec/provider.integration.spec.js
+++ b/spec/provider.integration.spec.js
@@ -42,11 +42,11 @@ describe("integration: core.rtcpeerconnection",
     require("freedom/providers/core/core.rtcdatachannel"),
     setup));
 
-describe("integration: core.xhr", 
-    require("freedom/spec/providers/coreIntegration/xhr.integration.src").bind(this, 
+describe("integration: core.xhr",
+    require("freedom/spec/providers/coreIntegration/xhr.integration.src").bind(this,
     require("freedom/providers/core/core.xhr"), setup));
 
-describe("integration: core.tcpsocket",
+fdescribe("integration: core.tcpsocket",
     require('freedom/spec/providers/coreIntegration/tcpsocket.integration.src').bind(this,
     require('../providers/core.tcpsocket'), setup));
 


### PR DESCRIPTION
Meant to fix #57 - not ready yet but opening for easier examination/discussion. Summary:

- The main goal is to ensure that onConnection/onDisconnect events are fired appropriately, particularly by client sockets.
- The approach I'm taking is to have the connect continuation also dispatch onConnection, and to always set an onDisconnect for that dispatch as well that should be automatically called.
- Per logging it does seem like the messages are firing in test, but the test still isn't passing (to reproduce, `grunt test` once to build the addon, then `cd .build` and `cfx run` and you can see logged output).

More investigation forthcoming.