### PR TITLE
remove onDisconnect for upgraded/secure sockets

### DIFF
--- a/providers/core.tcpsocket.js
+++ b/providers/core.tcpsocket.js
@@ -76,6 +76,7 @@ Socket_firefox.prototype.secure = function(continuation) {
   // and do a starttls flow (e.g. if there are 2 instances of a GTalk social
   // provider that are both trying to connect to GTalk simultaneously with
   // different logins).
+  this.clientSocket.onDisconnect = undefined;  // avoid undesired dispatching
   this.clientSocket = new ClientSocket();
   // TODO: DRY this code up (see 'connect' above)
   this.clientSocket.onDisconnect = function(err) {


### PR DESCRIPTION
In lieu of https://github.com/freedomjs/freedom-for-firefox/pull/60

Fixes https://github.com/freedomjs/freedom-for-firefox/issues/61

Doesn't change anything else, as something about the previous changes (possibly all the crazy continuation passing) was negatively affecting proxying stability. Still worth getting in this because it's basically the single thing blocking uProxy using up-to-date freedom-for-firefox (and thus collecting anonymized metrics, etc.).