### PR TITLE
Return the actual bound address, not a hardcoded "localhost".

### DIFF
--- a/providers/core.udpsocket.js
+++ b/providers/core.udpsocket.js
@@ -14,10 +14,14 @@ UDP_Firefox.prototype.bind = function(address, port, continuation) {
   // to these supported addresses.
   // TODO: Remove this check once https://bugzilla.mozilla.org/show_bug.cgi?id=1178427
   // is fixed.
-  var isLocal = address === '127.0.0.1' || address === 'localhost';
-  var isAny = address === '0.0.0.0';
+  var isLocal = address === "127.0.0.1" || address === "localhost";
+  var isAny = address === "0.0.0.0";
   if (!isLocal && !isAny) {
-    continuation(-1);
+    continuation(undefined, {
+      errcode: "INVALID_ARGUMENT",
+      message: "Can't bind " + address +
+          "; only 127.0.0.1 and 0.0.0.0 are supported in Firefox."
+    });
     return;
   }
   try {

--- a/providers/core.udpsocket.js
+++ b/providers/core.udpsocket.js
@@ -39,7 +39,7 @@ UDP_Firefox.prototype.bind = function(address, port, continuation) {
 UDP_Firefox.prototype.getInfo = function(continuation) {
   var returnValue = {
     localAddress: this._nsIUDPSocket.localAddr.address,
-    localPort: this._nsIUDPSocket.port
+    localPort: this._nsIUDPSocket.localAddr.port
   };
   continuation(returnValue);
 };

--- a/providers/core.udpsocket.js
+++ b/providers/core.udpsocket.js
@@ -9,10 +9,18 @@ UDP_Firefox.prototype.bind = function(address, port, continuation) {
   if (port < 1) {
     port = -1;
   }
+  // This interface appears to be IPv4-only, and only supports binding to
+  // localhost or any-interface.  To minimize confusion, we restrict binding
+  // to these supported addresses.
+  // TODO: Remove this check once https://bugzilla.mozilla.org/show_bug.cgi?id=1178427
+  // is fixed.
+  var isLocal = address === '127.0.0.1' || address === 'localhost';
+  var isAny = address === '0.0.0.0';
+  if (!isLocal && !isAny) {
+    continuation(-1);
+    return;
+  }
   try {
-    var isLocal = address === '127.0.0.1' ||
-        address === 'localhost' ||
-        address.match(/^(0*:)+0*1$/);  // ::1, 0:0:0:0:0:0:0:1, etc.
     this._nsIUDPSocket.init(port, isLocal);
     this._nsIUDPSocket.asyncListen(new nsIUDPSocketListener(this));
     continuation(0);

--- a/providers/core.udpsocket.js
+++ b/providers/core.udpsocket.js
@@ -10,7 +10,10 @@ UDP_Firefox.prototype.bind = function(address, port, continuation) {
     port = -1;
   }
   try {
-    this._nsIUDPSocket.init(port, false);
+    var isLocal = address === '127.0.0.1' ||
+        address === 'localhost' ||
+        address.match(/^(0*:)+0*1$/);
+    this._nsIUDPSocket.init(port, isLocal);
     this._nsIUDPSocket.asyncListen(new nsIUDPSocketListener(this));
     continuation(0);
   } catch (e) {
@@ -23,7 +26,7 @@ UDP_Firefox.prototype.bind = function(address, port, continuation) {
 
 UDP_Firefox.prototype.getInfo = function(continuation) {
   var returnValue = {
-    localAddress: "localhost",
+    localAddress: this._nsIUDPSocket.localAddr.address,
     localPort: this._nsIUDPSocket.port
   };
   continuation(returnValue);

--- a/providers/core.udpsocket.js
+++ b/providers/core.udpsocket.js
@@ -12,7 +12,7 @@ UDP_Firefox.prototype.bind = function(address, port, continuation) {
   try {
     var isLocal = address === '127.0.0.1' ||
         address === 'localhost' ||
-        address.match(/^(0*:)+0*1$/);
+        address.match(/^(0*:)+0*1$/);  // ::1, 0:0:0:0:0:0:0:1, etc.
     this._nsIUDPSocket.init(port, isLocal);
     this._nsIUDPSocket.asyncListen(new nsIUDPSocketListener(this));
     continuation(0);


### PR DESCRIPTION
This address will always be either '127.0.0.1' or '0.0.0.0',
because nsIUDPSocket::init only supports binding to localhost
or all-interfaces.

Addresses https://github.com/freedomjs/freedom-for-firefox/issues/62 and https://github.com/freedomjs/freedom-for-firefox/issues/67

@trevj