### PR TITLE
Makes udpsocket.bind() consistent with Freedom for Chrome

### DIFF
--- a/providers/core.udpsocket.js
+++ b/providers/core.udpsocket.js
@@ -14,7 +14,10 @@ UDP_Firefox.prototype.bind = function(address, port, continuation) {
     this._nsIUDPSocket.asyncListen(new nsIUDPSocketListener(this));
     continuation(0);
   } catch (e) {
-    continuation(-1);
+    continuation(undefined, {
+      errcode: "BIND_FAILED",
+      message: "Failed to Bind: " + e.message
+    });
   }
 };
 


### PR DESCRIPTION
Needed for freedomjs/freedom#280 and uproxy/uproxy#1700.