### PR TITLE
make website publish git clone work more generally

### DIFF
--- a/tools/publishWebsite.sh
+++ b/tools/publishWebsite.sh
@@ -8,7 +8,7 @@ TAG=$(git describe --abbrev=0 --tags)
 
 # Clone
 rm -rf build/freedomjs
-git clone git@github.com:freedomjs/freedomjs.github.io.git build/freedomjs
+git clone https://github.com/freedomjs/freedomjs.github.io.git build/freedomjs
 
 # Copy latest release
 mkdir -p build/freedomjs/dist/freedom-for-firefox


### PR DESCRIPTION
Not urgent - the `publishWebsite.sh` script fails ("Permission denied" public key mismatch) in its current form for me, whereas this version works (and I believe works more generally).