### PR TITLE
import crypto into global addon scope

### DIFF
--- a/src/entry.js
+++ b/src/entry.js
@@ -17,6 +17,7 @@ if (typeof Components !== 'undefined') {
   WebSocket = hiddenWindow.WebSocket;
   FileReader = hiddenWindow.FileReader;
 
+  Components.utils.importGlobalProperties(['crypto']);
   Components.utils.importGlobalProperties(['URL']);
 
   providers = [


### PR DESCRIPTION
Needed for crypto primitives to be visible. See: https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Language_Bindings/Components.utils.importGlobalProperties