### PR TITLE
fixes for TCP socket closure

### DIFF
--- a/providers/core.tcpsocket.js
+++ b/providers/core.tcpsocket.js
@@ -9,7 +9,6 @@ function Socket_firefox(cap, dispatchEvent, socketId) {
     this.clientSocket = incomingConnections[socketId];
     delete incomingConnections[socketId];
     this.clientSocket.setOnDataListener(this._onData.bind(this));
-    delete this.clientSocket.transport;  // new socket shouldn't be connected
   }
 }
 

--- a/providers/core.tcpsocket.js
+++ b/providers/core.tcpsocket.js
@@ -9,6 +9,15 @@ function Socket_firefox(cap, dispatchEvent, socketId) {
     this.clientSocket = incomingConnections[socketId];
     delete incomingConnections[socketId];
     this.clientSocket.setOnDataListener(this._onData.bind(this));
+    this.clientSocket.onDisconnect = function(err) {
+      if (!err) {
+        err = {
+          "errcode": "CONNECTION_CLOSED",
+          "message": "Connection closed gracefully"
+        };
+      }
+      this.dispatchEvent("onDisconnect", err);
+    }.bind(this);
   }
 }
 


### PR DESCRIPTION
Addresses:
 * https://github.com/freedomjs/freedom-for-firefox/issues/72
 * https://github.com/freedomjs/freedom-for-firefox/issues/77
 * https://github.com/uProxy/uproxy/issues/1775

Integration test here:
https://github.com/freedomjs/freedom/pull/289

Note that this *breaks* one of the existing integration tests, namely `Socket reusing id of closed socket is also closed failed`. Can you help me figure out why?