### PR TITLE
update path to Console.jsm module

### DIFF
--- a/src/entry.js
+++ b/src/entry.js
@@ -2,7 +2,7 @@ var providers;
 
 // When included as a jsm file.
 if (typeof Components !== 'undefined') {
-  Components.utils.import("resource://gre/modules/devtools/Console.jsm");
+  Components.utils.import("resource://gre/modules/Console.jsm");
   Components.utils.import("resource://gre/modules/Timer.jsm");
   Components.utils.import('resource://gre/modules/Services.jsm');
   XMLHttpRequest = Components.Constructor("@mozilla.org/xmlextras/xmlhttprequest;1", "nsIXMLHttpRequest");


### PR DESCRIPTION
Per https://github.com/uProxy/uproxy/issues/2426

Regardless of the outcome of your discussion with Mozilla re: jpm and addon signing, it seems that we'll need this change. Thanks for pursuing this!